### PR TITLE
Add file relative to current open file (fixes #11)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { workspace, window, Uri } from 'vscode';
 import * as path from 'path';
 
 // this method is called when your extension is activated
@@ -17,35 +18,71 @@ export function activate(context: vscode.ExtensionContext) {
 	var addFileCommand = vscode.commands.registerCommand('addfileextension.addFile', () => {
 		// The code you place here will be executed every time your command is executed
 
-		// Refuse to work when rootPath is undefined (no folder is open)
-		if(vscode.workspace.rootPath == undefined){
-			vscode.window.showErrorMessage("Please open a folder first.");
-			return;
+		// Get file path from active document, if there is one. There are 3 cases where there can be
+		// an activeTextEditor, but it's not a valid one for our purposes:
+		// 1) A non-editor pane (eg markdown preview). Here activeTextEditor.document will be null.
+		// 2) Default settings or keyboard shortcuts. These panes have the uri scheme: 'vscode'.
+		// 3) A new, unsaved, untitled document. These have no valid filename, simply Untitled-[X] 
+		// (though it may differ in other languages, so we test for the absence of slashes).
+		// In all these cases we treat it as there being no active document.
+		const activeDocumentUri: Uri = window.activeTextEditor && 
+			window.activeTextEditor.document && window.activeTextEditor.document.uri;
+		const activeFilePath: string = activeDocumentUri && activeDocumentUri.scheme !== 'vscode' 
+			&& activeDocumentUri.fsPath.match(/\/|\\/) && activeDocumentUri.fsPath;
+
+		// If we have no workspace nor valid file open, fall back on the built-in new file command
+		if(!workspace.rootPath && !activeFilePath){
+			return vscode.commands.executeCommand('workbench.action.files.newUntitledFile');
 		}
 
+		// Select a prompt based on the 3 allowed states re: workspace root and active document
+		const placeHolder = 
+			workspace.rootPath && !activeFilePath ?
+				"provide a file name relative to the project folder" :
+			!workspace.rootPath && activeFilePath ?
+				`provide a file name relative to '${path.basename(activeFilePath)}'` :
+			// both available
+				`provide a file name relative to '${path.basename(activeFilePath)}' `
+				+ `(or begin '/' for a path relative to the project folder)`;
+		const prompt = "Add New File...";
+		
 		// Prompt the user for a path
-		vscode.window.showInputBox({prompt: "Provide file path relative to project folder."}).then(function(psPath: string){
+		return window.showInputBox({placeHolder, prompt}).then(function(psPath: string){
+			// If esc was pressed, do nothing
+			if(psPath === undefined){
+				return;
+			}
+			
+			// If no text provided, fall back on the built-in new file command
+			if(psPath === ""){
+				return vscode.commands.executeCommand('workbench.action.files.newUntitledFile');
+			}
+			
+			// Input must be a valid filename (this could probably be improved)
+			if(psPath.match(/^[.\/\\]+$/)){
+				return window.showErrorMessage("You must provide a valid file name.");
+			}
 			
 			// Refuse to work if user input ends with a path separator
 			// Check both variants here, since we advertise windows users can use unix separators
 			if(psPath.endsWith('\\') || psPath.endsWith('/')){
-				vscode.window.showErrorMessage("Creating directories is not supported at this time, please specify a file.");
-				return;
+				return window.showErrorMessage("Creating directories is not supported at this time, please specify a file.");
 			}
 			
-			// Add leading path separator if necessary
-			if(!psPath.startsWith(path.sep)){
-				psPath = path.sep + psPath;
+			// If given path begins with slash, use project root path (if a folder is open)
+			const beginsWithSlash = psPath.match(/^\/|\\/);
+			if(beginsWithSlash && !workspace.rootPath){
+				return window.showErrorMessage("Paths beginnning with '/' not allowed when no project folder is open");
 			}
-			
-			// Add workspace folder to path
-			let lsFullpath: string = vscode.workspace.rootPath + psPath;
-			
-			// Correct path separators to platform default
-			// Allow windows users to use unix-like separators too
-			lsFullpath = path.normalize(lsFullpath.replace(/\//g, path.sep));
-			
-			
+			// Now we need to remove the slash, otherwise the psPath will be treated as an absolute path
+			psPath = beginsWithSlash ? psPath.substr(1) : psPath;
+
+			const basePath: string = activeFilePath && !beginsWithSlash ?
+				path.dirname(activeFilePath) : workspace.rootPath
+	
+			// path.resolve takes care of normalization and platform path separators
+			const lsFullpath: string = path.resolve(basePath, psPath);
+
 			vscode.workspace.openTextDocument(vscode.Uri.parse("untitled:" + lsFullpath)).then(function(poDocument: vscode.TextDocument){
 				vscode.window.showTextDocument(poDocument).then(function(poEditor: vscode.TextEditor){
 					//
@@ -59,6 +96,6 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showErrorMessage("Could not open InputBox: " + reason);
 		});
 	});
-	
+
 	context.subscriptions.push(addFileCommand);
 }


### PR DESCRIPTION
As often is the case, this turned out to be more complicated than expected, with a number of edge-cases to deal with, so here's a load of text explaining everything.

The basic functionality is as described by @moostad in #11, where paths given will be used relative to the current open file, unless they begin with `/` or `\`, where they'll then be used relative to the project root folder instead (if there is one).

Table of behaviors:

| Project folder open | Text editor open | Given path begins with '/' | Behavior |
| --- | --- | --- | --- |
| ✓ | ✓ | ✓ | Create path relative to workspace root |
| ✓ | ✓ | ✗ | Create path relative to active file |
| ✓ | ✗ | ✓ | Create path relative to workspace root |
| ✓ | ✗ | ✗ | Create path relative to workspace root |
| ✗ | ✓ | ✓ | Error message: "Paths beginnning with '/' not allowed when no project folder is open" |
| ✗ | ✓ | ✗ | Create path relative to active file |
| ✗ | ✗ | N/A | Falls back on the built-in new file command |

There are a few cases where the current open pane is not a valid document to use for creating a relative file path; all cases here are treated as if there's no text editor open (details in the code).

Have changed the behavior from the current version, which requires a project folder to be open to work. Now if there's no folder open but there is a file it'll use the open file as the base path.
If there's no folder and no file open, it falls back on the built-in new file command, which creates a new untitled file. Have done this because I like to bind "addfileextension.addFile" to `ctrl+n` and have it replace the built-in comand, but sometimes I do still want an new empty text document without caring about the file name.

The text in the prompt given also depends on these states. It was a bit tricky here to come up with descriptive text that fits in the available space. Have moved the text up into the placeholder text of the input box, so that there's still room underneath for the "Press Enter to confirm or Escape to cancel".

Folder open, no file open
<img alt="foldernofile" src="https://cloud.githubusercontent.com/assets/6125444/14215509/bbcd1750-f843-11e5-9323-cea5786ed831.png">

File open, no folder open
<img alt="filenofolder" src="https://cloud.githubusercontent.com/assets/6125444/14215519/c6985f8c-f843-11e5-871e-f7ebbb1cd533.png">

Both file and folder open
<img alt="folderfile" src="https://cloud.githubusercontent.com/assets/6125444/14215531/d4179eac-f843-11e5-9ebd-1232f8e479c8.png">

---

Also:
- Have done some basic validation on the input file name (addresses #1)
- However if the input is left empty but Enter pressed, it falls back on the built-in command, for the same reason given above. (The extension currently errors when no text given).

Also removed some code that dealt with path separators: was not needed as the Node path functions do this for us.
