### PR TITLE
BUGFIX: Using backslashes causes things to break

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 			
 			// If given path begins with slash, use project root path (if a folder is open)
-			const beginsWithSlash = psPath.match(/^\/|\\/);
+			const beginsWithSlash = psPath.match(/^[\/\\]/);
 			if(beginsWithSlash && !workspace.rootPath){
 				return window.showErrorMessage("Paths beginnning with '/' not allowed when no project folder is open");
 			}


### PR DESCRIPTION
The last PR introduced a bug, where using backslash in the input filename would create a broken path for the new file (when using forward slashes everything's fine).

Sorry about that. This commit fixes it.
