### PR TITLE
Fix for paths containing a '#'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
 	"name": "addfileextension",
 	"displayName": "AddFileExtension",
 	"description": "Allows to add a file by giving a path relative to the working folder.",
-	"repository" : {
-	"type" : "git"
-	, "url" : "https://github.com/bgse/vsc-addfileextension.git"
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/bgse/vsc-addfileextension.git"
 	},
 	"version": "0.1.4",
 	"publisher": "bgse",
 	"engines": {
-		"vscode": "^0.10.1"
+		"vscode": "^1.20.0"
 	},
 	"categories": [
 		"Other"
@@ -19,17 +19,22 @@
 	],
 	"main": "./out/src/extension",
 	"contributes": {
-		"commands": [{
-			"command": "addfileextension.addFile",
-			"title": "Folder: Add File"
-		}]
+		"commands": [
+			{
+				"command": "addfileextension.addFile",
+				"title": "Folder: Add File"
+			}
+		]
 	},
 	"scripts": {
-		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+		"vscode:prepublish": "tsc -p ./",
+		"compile": "tsc -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"devDependencies": {
-		"typescript": "^1.6.2",
-		"vscode": "0.10.x"
+		"typescript": "^2.6.1",
+		"vscode": "^1.1.6",
+		"@types/node": "^7.0.43",
+		"@types/mocha": "^2.2.42"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,9 +81,9 @@ export function activate(context: vscode.ExtensionContext) {
 				path.dirname(activeFilePath) : workspace.rootPath
 	
 			// path.resolve takes care of normalization and platform path separators
-			const lsFullpath: string = path.resolve(basePath, psPath);
+			const uri = vscode.Uri.file(path.resolve(basePath, psPath)).with({scheme: "untitled"});
 
-			vscode.workspace.openTextDocument(vscode.Uri.parse("untitled:" + lsFullpath)).then(function(poDocument: vscode.TextDocument){
+			vscode.workspace.openTextDocument(uri).then(function(poDocument: vscode.TextDocument){
 				vscode.window.showTextDocument(poDocument).then(function(poEditor: vscode.TextEditor){
 					//
 				}, function(reason: any){

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"target": "ES6",
+		"rootDir": ".",
 		"outDir": "out",
-		"noLib": true,
+		"lib": ["es6"],
 		"sourceMap": true
 	},
 	"exclude": [
 		"node_modules"
-	]
+    ]
 }

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
Hi, hope you're still here :)

Despite there being other new-file extensions I haven't found another that's as simple and does exactly what I want like this one, so I still use it.

However I came across an issue where if the path to the new file contains a `#`, then it gets truncated and creation fails.

Had to update some dependencies and things to get it to compile again first.